### PR TITLE
Refactor Bootstrap #19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Refactored Boostrap #19 to not use event emitter to allow wrapping
+
 ## [0.3.1] - 2017-04-01
 
 ### Added

--- a/src/App.php
+++ b/src/App.php
@@ -58,14 +58,17 @@ class App extends Cargo\Container\ContainerDecorator implements EventEmitter, Lo
 
     public function bootstrap(callable $bootstrap = null) {
         if ($bootstrap) {
-            return $this->on(Events::BOOTSTRAP, $bootstrap);
+            return $this['bootstrappers']->append($bootstrap);
         }
 
         if ($this['bootstrapped']) {
             return;
         }
 
-        $this->emit(Events::BOOTSTRAP, $this);
+        foreach ($this['bootstrappers'] as $bootstrap) {
+            $bootstrap($this);
+        }
+
         $this['bootstrapped'] = true;
     }
 }

--- a/src/LavaPackage.php
+++ b/src/LavaPackage.php
@@ -131,6 +131,7 @@ class LavaPackage extends AbstractPackage
 
         $c['commands'] = new ArrayObject();
         $c['bootstrapped'] = false;
+        $c['bootstrappers'] = new ArrayObject();
         $c['frozen'] = false;
         $c['debug'] = false;
         $c['version'] = '0.3.1';

--- a/test/app.php
+++ b/test/app.php
@@ -2,6 +2,7 @@
 
 use Krak\Lava;
 use Krak\Cargo;
+use Krak\EventEmitter\EventEmitter;
 
 beforeEach(function() {
     $this->app = new Lava\App(__DIR__);
@@ -38,6 +39,27 @@ describe('->with', function() {
         };
         $this->app->with($package);
         assert($this->app->has('a') === false);
+        $this->app->bootstrap();
+        assert($this->app['a'] == 5);
+    });
+});
+describe('->bootstrap', function() {
+    it('allows for the Event Emitters to be extended', function() {
+        $package = new class() extends Lava\AbstractPackage {
+            public function bootstrap(Lava\App $app) {
+                $app['a'] = 5;
+            }
+            public function with(Lava\App $app) {
+                $app->wrap(EventEmitter::class, function($emitter) {
+                    return $emitter;
+                });
+            }
+        };
+
+        $this->app->bootstrap(function($app) {
+            $app['a'] = 1;
+        });
+        $this->app->with($package);
         $this->app->bootstrap();
         assert($this->app['a'] == 5);
     });


### PR DESCRIPTION
Refactored the bootstrap process to no longer use
the event emitter so that we can extend it in the
Packages.

Signed-off-by: RJ Garcia <rj@bighead.net>