### PR TITLE
Fix expects and parseJson #22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- expects and parseJson behavior now properly parse content types. #22
 - Refactored Boostrap #19 to not use event emitter to allow wrapping
 
 ## [0.3.1] - 2017-04-01

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "krak/cargo": "^0.2.0",
         "krak/event-emitter": "^0.1.0",
         "krak/http": "^0.3.0",
+        "krak/http-message": "^0.1.3",
         "krak/mw": "^0.5.1",
         "nikic/fast-route": "^1.2",
         "nikic/iter": "^1.4",

--- a/test/lava.spec.php
+++ b/test/lava.spec.php
@@ -26,4 +26,7 @@ describe('Krak Lava', function() {
             });
         }
     });
+    describe('Middleware', function() {
+        require_once __DIR__ . '/middleware/mw.php';
+    });
 });

--- a/test/middleware/mw.php
+++ b/test/middleware/mw.php
@@ -1,0 +1,52 @@
+<?php
+
+use Zend\Diactoros\ServerRequest;
+use Psr\Http\Message\ResponseInterface;
+use Krak\Lava;
+use Krak\Http;
+
+beforeEach(function() {
+    $this->app = new Krak\Lava\App(__DIR__);
+});
+
+describe('#expectsContentType', function() {
+    beforeEach(function() {
+        $this->app->routes(function($routes) {
+            $routes->get('/', function() {
+                return "abc";
+            })->with('expects', 'application/json');
+        });
+    });
+    it('checks nothing if no content-type exists', function() {
+        $req = new ServerRequest([], [], '/', 'GET');
+        $resp = $this->app->handleRequest($req);
+        assert($resp->getStatusCode() == 200);
+    });
+    it('passes through if the content type matches', function() {
+        $req = new ServerRequest([], [], '/', 'GET', 'php://temp', ['Content-Type' => 'application/json;charset=UTF-8']);
+        $resp = $this->app->handleRequest($req);
+        assert($resp->getStatusCode() == 200);
+    });
+    it('returns a 415 error if content type does not match', function() {
+        $req = new ServerRequest([], [], '/', 'GET', 'php://temp', ['Content-Type' => 'text/html;charset=UTF-8']);
+        $resp = $this->app->handleRequest($req);
+        assert($resp->getStatusCode() == 415);
+    });
+});
+describe('#parseJson', function() {
+    it('parses JSON requests into the body', function() {
+        $this->app->routes(function($routes) {
+            $routes->post('/', function($req) {
+                $data = $req->getParsedBody();
+                assert($data[0] == 1 && $data[1] == 2);
+                return "";
+            });
+        });
+        $stream = fopen("php://temp", "rw");
+        fwrite($stream, "[1,2]");
+        rewind($stream);
+        $req = new ServerRequest([], [], '/', 'POST', $stream, ['Content-Type' => 'application/json;charset=UTF-8']);
+        $resp = $this->app->handleRequest($req);
+        assert($resp->getStatusCode() == 200);
+    });
+});


### PR DESCRIPTION
- Added HttpMessage library
- expects and parseJson now properly parse content type headers
- expects now only throws message when a content-type exists

Signed-off-by: RJ Garcia <rj@bighead.net>